### PR TITLE
Update supervisord.conf [supervisord] logfile

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,7 @@
 [supervisord]
 user=root
 nodaemon=true
-logfile=/dev/null
+logfile=/dev/stdout
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 loglevel = INFO


### PR DESCRIPTION
For some reasons, i'm not sure why, but supervisord always quit when i run image via swarm.
I had such logs.
...
laravel_app.1.xfhjdtssb63x@docker-desktop    | [20-Nov-2021 13:03:40] NOTICE: ready to handle connections
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:41,177 INFO success: php-fpm entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:41,177 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 BLAT EINTR encountered in poll
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 WARN received SIGQUIT indicating exit request
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 DEBG killing nginx (pid 66) with signal SIGTERM
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 INFO waiting for nginx, php-fpm to die
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 BLAT nginx state: STOPPING
laravel_app.1.xfhjdtssb63x@docker-desktop    | 2021-11-20 13:03:52,067 BLAT php-fpm state: RUNNING
...

And i was able to fix it only after i changed as in supervisord documentation -- http://supervisord.org/configuration.html#supervisord-section-values

from /dev/null to /dev/stdout

So, I propose to update this part.